### PR TITLE
feat: multi-part blog series support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ tsconfig.tsbuildinfo
 .crush
 .pi
 .pi-lens
+
+# Pix Agent
+.pi/
+.pi-lens/

--- a/src/content/blog/ai-agents-for-businesses/june-01-2026.md
+++ b/src/content/blog/ai-agents-for-businesses/june-01-2026.md
@@ -2,6 +2,9 @@
 title: "June 01 2026"
 pubDate: 2026-06-01
 draft: false
+series: "ai-agents-for-businesses"
+partNumber: 1
+partTitle: "June 01 2026"
 ---
 
 ## June 01 2026

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,31 +1,34 @@
 import { defineCollection, z } from "astro:content";
 
 const blog = defineCollection({
-  type: "content",
-  schema: z.object({
-    title: z.string(),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    heroImage: z.string().optional(),
-    author: z.string().optional(),
-    authorImage: z.string().optional(),
-    authorEmail: z.string().optional(),
-    authorPhone: z.string().optional(),
-    draft: z.boolean().default(false).optional(),
-  }),
+	type: "content",
+	schema: z.object({
+		title: z.string(),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
+		heroImage: z.string().optional(),
+		author: z.string().optional(),
+		authorImage: z.string().optional(),
+		authorEmail: z.string().optional(),
+		authorPhone: z.string().optional(),
+		draft: z.boolean().default(false).optional(),
+		series: z.string().optional(),
+		partNumber: z.number().optional(),
+		partTitle: z.string().optional(),
+	}),
 });
 
 const codingSessions = defineCollection({
-  type: "content",
-  schema: z.object({
-    title: z.string(),
-    pubDate: z.coerce.date(),
-    description: z.string(),
-    model: z.string().optional(),
-    cost: z.string().optional(),
-    tokens: z.string().optional(),
-    draft: z.boolean().default(false).optional(),
-  }),
+	type: "content",
+	schema: z.object({
+		title: z.string(),
+		pubDate: z.coerce.date(),
+		description: z.string(),
+		model: z.string().optional(),
+		cost: z.string().optional(),
+		tokens: z.string().optional(),
+		draft: z.boolean().default(false).optional(),
+	}),
 });
 
 export const collections = { blog, "coding-sessions": codingSessions };

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -14,6 +14,20 @@ type Props = CollectionEntry<"blog">;
 
 const post = Astro.props;
 const { Content } = await post.render();
+
+let seriesPosts: CollectionEntry<"blog">[] = [];
+let prevPart: CollectionEntry<"blog"> | undefined;
+let nextPart: CollectionEntry<"blog"> | undefined;
+
+if (post.data.series) {
+    const allPosts = await getCollection("blog", ({ data }) => !data.draft);
+    seriesPosts = allPosts
+        .filter((p) => p.data.series === post.data.series)
+        .sort((a, b) => (a.data.partNumber ?? 0) - (b.data.partNumber ?? 0));
+    const currentIndex = seriesPosts.findIndex((p) => p.slug === post.slug);
+    if (currentIndex > 0) prevPart = seriesPosts[currentIndex - 1];
+    if (currentIndex < seriesPosts.length - 1) nextPart = seriesPosts[currentIndex + 1];
+}
 ---
 
 <Layout title={post.data.title}>
@@ -66,10 +80,61 @@ const { Content } = await post.render();
 
         <main class="px-6 pb-24 mt-6">
             <article class="mx-auto max-w-2xl">
+                {post.data.series && seriesPosts.length > 1 && (
+                    <div class="mb-8 p-4 rounded-lg bg-neutral-900/50 border border-neutral-800">
+                        <p class="text-xs font-mono text-neutral-500 uppercase tracking-wider mb-2">
+                            Series · Part {post.data.partNumber} of {seriesPosts.length}
+                        </p>
+                        <p class="text-sm text-neutral-300 font-serif italic">
+                            {post.data.series.split("-").map((w: string) => w[0].toUpperCase() + w.slice(1)).join(" ")}
+                        </p>
+                        <div class="mt-3 flex flex-wrap gap-2">
+                            {seriesPosts.map((sp) => (
+                                <a
+                                    href={`/blog/${sp.slug}`}
+                                    class:list={["text-xs px-2 py-1 rounded border transition-colors",
+                                        sp.slug === post.slug
+                                            ? "bg-[#228B22]/20 border-[#228B22] text-[#228B22]"
+                                            : "bg-neutral-800/50 border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:border-neutral-500"
+                                    ]}
+                                >
+                                    Part {sp.data.partNumber}
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 <div class="prose max-w-none">
                     <Content />
                 </div>
             </article>
+
+            {(prevPart || nextPart) && (
+                <div class="mx-auto max-w-2xl mt-12 flex justify-between gap-4">
+                    {prevPart ? (
+                        <a
+                            href={`/blog/${prevPart.slug}`}
+                            class="flex-1 p-4 rounded-lg bg-neutral-900/50 border border-neutral-800 hover:border-neutral-600 transition-all duration-300 no-underline"
+                        >
+                            <p class="text-xs font-mono text-neutral-500">← Previous</p>
+                            <p class="text-sm text-neutral-300 font-serif italic mt-1">
+                                Part {prevPart.data.partNumber}: {prevPart.data.partTitle || prevPart.data.title}
+                            </p>
+                        </a>
+                    ) : <div class="flex-1" />}
+                    {nextPart ? (
+                        <a
+                            href={`/blog/${nextPart.slug}`}
+                            class="flex-1 p-4 rounded-lg bg-neutral-900/50 border border-neutral-800 hover:border-neutral-600 transition-all duration-300 no-underline text-right"
+                        >
+                            <p class="text-xs font-mono text-neutral-500">Next →</p>
+                            <p class="text-sm text-neutral-300 font-serif italic mt-1">
+                                Part {nextPart.data.partNumber}: {nextPart.data.partTitle || nextPart.data.title}
+                            </p>
+                        </a>
+                    ) : <div class="flex-1" />}
+                </div>
+            )}
         </main>
     </div>
 </Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,10 +1,33 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 
-const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
+const allPosts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+
+// Group series posts, keep standalone posts as-is
+// Use the latest post date in a series for ordering
+const seenSeries = new Set<string>();
+const grouped: Array<{ type: "post"; post: CollectionEntry<"blog"> } | { type: "series"; seriesSlug: string; posts: CollectionEntry<"blog">[] }> = [];
+
+for (const post of allPosts) {
+  if (post.data.series) {
+    if (seenSeries.has(post.data.series)) continue;
+    seenSeries.add(post.data.series);
+    const seriesPosts = allPosts
+      .filter((p) => p.data.series === post.data.series)
+      .sort((a, b) => (a.data.partNumber ?? 0) - (b.data.partNumber ?? 0));
+    grouped.push({ type: "series", seriesSlug: post.data.series, posts: seriesPosts });
+  } else {
+    grouped.push({ type: "post", post });
+  }
+}
+
+function titleCase(slug: string) {
+  return slug.split("-").map((w) => w[0].toUpperCase() + w.slice(1)).join(" ");
+}
 ---
 
 <Layout
@@ -55,33 +78,74 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 
     <main class="px-6 pb-24 mt-6">
       <div class="mx-auto max-w-2xl space-y-4">
-        {
-          posts.map((post) => (
-            <a
-              href={`/blog/${post.slug}`}
-              class="block p-6 rounded-lg bg-neutral-900/50 border border-neutral-800 hover:border-neutral-600 transition-all duration-300 no-underline hover:no-underline group"
-            >
-              <h3 class="text-xl font-serif italic text-neutral-200 group-hover:text-white transition-colors leading-snug">
-                {post.data.title}
-              </h3>
-              <div class="mt-3 flex items-center gap-3">
-                <time
-                  datetime={post.data.pubDate.toISOString()}
-                  class="text-xs font-mono text-neutral-600"
-                >
-                  {post.data.pubDate.toLocaleDateString("en-us", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                </time>
-                {post.data.author && (
-                  <span class="text-xs text-neutral-600">· {post.data.author}</span>
-                )}
+        {grouped.map((item) => {
+          if (item.type === "post") {
+            const post = item.post;
+            return (
+              <a
+                href={`/blog/${post.slug}`}
+                class="block p-6 rounded-lg bg-neutral-900/50 border border-neutral-800 hover:border-neutral-600 transition-all duration-300 no-underline hover:no-underline group"
+              >
+                <h3 class="text-xl font-serif italic text-neutral-200 group-hover:text-white transition-colors leading-snug">
+                  {post.data.title}
+                </h3>
+                <div class="mt-3 flex items-center gap-3">
+                  <time
+                    datetime={post.data.pubDate.toISOString()}
+                    class="text-xs font-mono text-neutral-600"
+                  >
+                    {post.data.pubDate.toLocaleDateString("en-us", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </time>
+                  {post.data.author && (
+                    <span class="text-xs text-neutral-600">· {post.data.author}</span>
+                  )}
+                </div>
+              </a>
+            );
+          }
+
+          const { seriesSlug, posts: seriesPosts } = item;
+          return (
+            <div class="p-6 rounded-lg bg-neutral-900/50 border border-neutral-800">
+              <div class="flex items-center gap-3 mb-4">
+                <span class="text-xs font-mono text-[#228B22] uppercase tracking-wider">Series</span>
+                <h3 class="text-xl font-serif italic text-neutral-200 leading-snug">
+                  {titleCase(seriesSlug)}
+                </h3>
+                <span class="text-xs font-mono text-neutral-600">{seriesPosts.length} part{seriesPosts.length > 1 ? "s" : ""}</span>
               </div>
-            </a>
-          ))
-        }
+              <div class="space-y-2">
+                {seriesPosts.map((sp) => (
+                  <a
+                    href={`/blog/${sp.slug}`}
+                    class="block p-3 rounded-lg border border-neutral-800 hover:border-neutral-600 transition-all duration-300 no-underline hover:no-underline group"
+                  >
+                    <div class="flex items-center gap-3">
+                      <span class="text-xs font-mono text-neutral-600">Part {sp.data.partNumber}</span>
+                      <span class="text-sm font-serif italic text-neutral-300 group-hover:text-white transition-colors">
+                        {sp.data.partTitle || sp.data.title}
+                      </span>
+                    </div>
+                    <time
+                      datetime={sp.data.pubDate.toISOString()}
+                      class="mt-1 ml-12 block text-xs font-mono text-neutral-600"
+                    >
+                      {sp.data.pubDate.toLocaleDateString("en-us", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </time>
+                  </a>
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary

Add multi-part blog series support: posts can be grouped into an ordered series and rendered with part numbers/titles on the blog index and post pages.

## Changes
- `src/content/config.ts`: add `series`, `partNumber`, `partTitle` fields to blog schema
- `src/pages/blog/index.astro`: group/sort posts by series
- `src/pages/blog/[...slug].astro`: render series navigation (new file)
- `src/components/bifrost-chart-data.ts`: data refresh
- Draft content updates
- `chore: ignore `.pi/` and `.pi-lens/` agent dirs

## Commits
- `639840d` chore: update draft
- `eb0eaf3` feat: add multi-part series support for blog posts
- `b48882f` chore: ignore .pi/ and .pi-lens/ agent dirs