### PR TITLE
feat: responsive mobile header nav + Mad Cactus tagline

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -37,22 +37,25 @@ const nav: Array<{
         style="mask-image: linear-gradient(to bottom, black 70%, transparent); -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent);"
     />
     <div class="relative z-10 mx-auto max-w-2xl">
-        <div class="flex justify-between items-center mb-6">
+        <div class="flex justify-between items-center mb-6 gap-3">
             {
                 home ? (
-                    <h1 class="text-2xl tracking-tight md:text-3xl font-logo">
+                    <h1 class="text-lg xs:text-xl sm:text-2xl md:text-3xl tracking-tight font-logo">
                         Collin Pfeifer
                     </h1>
                 ) : (
                     <a
                         href="/"
-                        class="text-2xl tracking-tight md:text-3xl font-logo no-underline hover:no-underline text-white"
+                        class="text-lg xs:text-xl sm:text-2xl md:text-3xl tracking-tight font-logo no-underline hover:no-underline text-white whitespace-nowrap"
                     >
                         Collin Pfeifer
                     </a>
                 )
             }
-            <div class="flex gap-6 text-sm font-mono text-neutral-400">
+            <nav
+                class="flex gap-2.5 xs:gap-3 sm:gap-5 md:gap-6 text-xs xs:text-sm font-mono text-neutral-400"
+                aria-label="Primary"
+            >
                 {
                     nav.map((item) => (
                         <a
@@ -65,28 +68,28 @@ const nav: Array<{
                             }
                             class={
                                 active === item.key
-                                    ? "text-neutral-200"
-                                    : "hover:text-neutral-200 transition-colors"
+                                    ? "text-neutral-200 whitespace-nowrap"
+                                    : "hover:text-neutral-200 transition-colors whitespace-nowrap"
                             }
                         >
                             {item.label}
                         </a>
                     ))
                 }
-            </div>
+            </nav>
         </div>
 
         {
             tagline && (
                 <p class="mt-2 text-neutral-400">
-                    Craftsman. Working on 🦌{" "}
+                    Craftsman. Working on 🌵{" "}
                     <a
-                        href="https://trydeer.sh"
+                        href="https://madcactus.org"
                         target="_blank"
-                        class="hover:text-[#228B22] transition-colors"
+                        class="hover:text-neutral-200 transition-colors"
                         rel="noopener noreferrer"
                     >
-                        deer.sh
+                        Mad Cactus
                     </a>
                 </p>
             )

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,13 +103,13 @@ import Header from "../components/Header.astro";
                     I taught myself coding in high school and have done various
                     ventures like consulting for startups, freelancing, and some
                     service-based businesses when I was younger. Currently I am
-                    building 🦌 <a
-                        href="https://trydeer.sh"
+                    building 🌵 <a
+                        href="https://madcactus.org"
                         target="_blank"
-                        class="hover:text-[#228B22] transition-colors"
+                        class="hover:text-neutral-200 transition-colors"
                         rel="noopener noreferrer"
                     >
-                        deer.sh</a
+                        Mad Cactus</a
                     >.
                 </p>
                 <p class="mt-8 text-neutral-400">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,7 @@
 @theme {
     --font-logo: "NeueMachina", ui-sans-serif, system-ui;
     --font-serif: "Instrument Serif", Georgia, "Times New Roman", serif;
+    --breakpoint-xs: 400px;
 }
 
 @font-face {


### PR DESCRIPTION
## What changed

### Mobile header nav
The nav links were squished and the name looked cramped on small screens. Switched to **dynamic inline spacing** (no overlay):
- Name scales `text-lg → xs:text-xl → sm:text-2xl → md:text-3xl`
- Nav gap scales `gap-2.5 → xs:gap-3 → sm:gap-5 → md:gap-6`, link size `text-xs → xs:text-sm`
- `whitespace-nowrap` on name + links so nothing wraps
- Added `--breakpoint-xs: 400px` to `global.css` for the intermediate step
- Preserved the full `Header` props (`active` / `home` / `tagline`), the `<h1>` vs link toggle, active-state highlighting, and the `<slot>` — so all 6 pages using `<Header>` keep working

### Tagline + body → Mad Cactus
- Tagline: `Craftsman. Working on 🌵 Mad Cactus` → links to https://madcactus.org
- Home body paragraph: swapped `🦌 deer.sh` → `🌵 Mad Cactus` (same link)
- Link hover matches the header nav style (`hover:text-neutral-200`)

## Verified
- `bun run build` → clean, 6 pages generated

## Out of scope / notes
- `bun lint` is documented in `AGENTS.md` but not actually defined in `package.json` — pre-existing, not from this change.