### PR TITLE
feat: embeddable poker graph (OG image for Notes/link previews)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # build output
 dist/
 
+# generated OG images (built by scripts/gen-og.ts on `bun run build`)
+public/og/*.png
+
 # generated types
 .astro/
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import rehypeKatex from "rehype-katex";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://collinpfeifer.dev",
+  site: "https://www.collinpfeifer.dev",
   integrations: [mdx()],
   markdown: {
     remarkPlugins: [remarkMath],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import rehypeKatex from "rehype-katex";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://collinpfeifer.dev",
   integrations: [mdx()],
   markdown: {
     remarkPlugins: [remarkMath],

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@astrojs/mdx": "^4.3.13",
+        "@napi-rs/canvas": "^1.0.2",
         "@supabase/supabase-js": "^2.105.1",
         "@tailwindcss/vite": "^4.1.18",
         "@types/node": "^25.6.0",
@@ -176,6 +177,30 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@1.0.2", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.2", "@napi-rs/canvas-darwin-arm64": "1.0.2", "@napi-rs/canvas-darwin-x64": "1.0.2", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2", "@napi-rs/canvas-linux-arm64-gnu": "1.0.2", "@napi-rs/canvas-linux-arm64-musl": "1.0.2", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2", "@napi-rs/canvas-linux-x64-gnu": "1.0.2", "@napi-rs/canvas-linux-x64-musl": "1.0.2", "@napi-rs/canvas-win32-arm64-msvc": "1.0.2", "@napi-rs/canvas-win32-x64-msvc": "1.0.2" } }, "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@1.0.2", "", { "os": "android", "cpu": "arm64" }, "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@1.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@1.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@1.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@1.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@1.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "bun run gen:og && astro build",
+    "gen:og": "bun run scripts/gen-og.ts",
     "preview": "astro preview",
     "check": "astro check",
     "astro": "astro",
@@ -13,6 +14,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "@astrojs/mdx": "^4.3.13",
+    "@napi-rs/canvas": "^1.0.2",
     "@supabase/supabase-js": "^2.105.1",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^25.6.0",

--- a/scripts/gen-og.ts
+++ b/scripts/gen-og.ts
@@ -1,0 +1,181 @@
+// Generates public/og/poker.png — a 1200x630 snapshot of the poker graph for
+// OpenGraph / Apple Notes rich link previews. Runs at build (see package.json
+// "build") and can be invoked directly: `bun run gen:og`.
+//
+// Reuses the same data layer + drawChart as the live page, so the preview
+// matches what's on collinpfeifer.dev/poker.
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createCanvas, GlobalFonts } from "@napi-rs/canvas";
+import {
+  parseLog,
+  processSessions,
+  emptyChartData,
+  type PokerChartData,
+} from "../src/components/poker-chart-data";
+import {
+  drawChart,
+  fmtSigned,
+  GREEN,
+  RED,
+  type ChartCtx,
+} from "../src/components/poker-chart-render";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "..");
+const logPath = join(repoRoot, "src/content/poker/log.md");
+const fontsDir = join(repoRoot, "public/fonts");
+const outPath = join(repoRoot, "public/og/poker.png");
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+const FAMILY = "NeueMachina";
+const FAMILY_BOLD = "NeueMachina Ultrabold";
+const FAMILY_LIGHT = "NeueMachina Light";
+
+function registerFonts() {
+  // @napi-rs/canvas maps each file to a family name; weights become separate
+  // families since it doesn't parse weight from the OTF.
+  GlobalFonts.registerFromPath(join(fontsDir, "NeueMachina-Regular.otf"), FAMILY);
+  GlobalFonts.registerFromPath(join(fontsDir, "NeueMachina-Ultrabold.otf"), FAMILY_BOLD);
+  GlobalFonts.registerFromPath(join(fontsDir, "NeueMachina-Light.otf"), FAMILY_LIGHT);
+}
+
+function roundRect(
+  ctx: ChartCtx,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+interface Stat {
+  value: string;
+  label: string;
+}
+
+function buildStats(data: PokerChartData): Stat[] {
+  const t = data.totals;
+  return [
+    { value: t.sessions.toString(), label: "sessions" },
+    {
+      value: t.sessions > 0 ? Math.round((t.wins / t.sessions) * 100) + "%" : "—",
+      label: "win %",
+    },
+    {
+      value:
+        t.hours > 0
+          ? (t.bbPerHour >= 0 ? "+" : "") + t.bbPerHour.toFixed(1)
+          : "—",
+      label: "bb/hr",
+    },
+    {
+      value: t.biggestWin > 0 ? fmtSigned(t.biggestWin) : "—",
+      label: "biggest win",
+    },
+  ];
+}
+
+export function generatePokerOg(): Buffer {
+  const md = readFileSync(logPath, "utf8");
+  const sessions = parseLog(md);
+  const data = sessions.length ? processSessions(sessions) : emptyChartData();
+
+  registerFonts();
+
+  const canvas = createCanvas(WIDTH, HEIGHT);
+  const ctx = canvas.getContext("2d");
+
+  // background
+  ctx.fillStyle = "#000000";
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  const t = data.totals;
+
+  // header: label (left) + net (right)
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.fillStyle = "#737373";
+  ctx.font = `22px ${FAMILY_BOLD}`;
+  ctx.fillText("POKER GRAPH", 60, 58);
+
+  ctx.textAlign = "right";
+  ctx.fillStyle = t.net > 0 ? GREEN : t.net < 0 ? RED : "#a3a3a3";
+  ctx.font = `68px ${FAMILY_BOLD}`;
+  ctx.fillText(fmtSigned(t.net), WIDTH - 60, 44);
+
+  // stats row
+  const stats = buildStats(data);
+  ctx.textAlign = "left";
+  let sx = 60;
+  for (const s of stats) {
+    ctx.fillStyle = "#d4d4d4";
+    ctx.font = `26px ${FAMILY}`;
+    ctx.fillText(s.value, sx, 138);
+    ctx.fillStyle = "#525252";
+    ctx.font = `13px ${FAMILY}`;
+    ctx.fillText(s.label.toUpperCase(), sx, 172);
+    sx += 260;
+  }
+
+  // chart panel
+  const panelX = 40;
+  const panelY = 206;
+  const panelW = WIDTH - 80;
+  const panelH = HEIGHT - panelY - 30;
+  ctx.fillStyle = "rgba(23, 23, 23, 0.5)";
+  roundRect(ctx, panelX, panelY, panelW, panelH, 12);
+  ctx.fill();
+  ctx.strokeStyle = "#262626";
+  ctx.lineWidth = 1;
+  roundRect(ctx, panelX, panelY, panelW, panelH, 12);
+  ctx.stroke();
+
+  // chart on its own canvas, then stamp onto the card
+  const chartPad = 16;
+  const chartW = panelW - chartPad * 2;
+  const chartH = panelH - chartPad * 2;
+  const chartCanvas = createCanvas(chartW, chartH);
+  const chartCtx = chartCanvas.getContext("2d");
+
+  if (data.points.length > 0) {
+    drawChart(chartCtx, data, chartW, chartH, { fontFamily: FAMILY, scale: 1.7 });
+  } else {
+    chartCtx.fillStyle = "#525252";
+    chartCtx.font = `16px ${FAMILY}`;
+    chartCtx.textAlign = "center";
+    chartCtx.textBaseline = "middle";
+    chartCtx.fillText("No sessions logged yet", chartW / 2, chartH / 2);
+  }
+
+  // @napi-rs/canvas drawImage accepts a canvas source
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ctx as any).drawImage(chartCanvas, panelX + chartPad, panelY + chartPad);
+
+  return canvas.toBuffer("image/png");
+}
+
+function main() {
+  const buf = generatePokerOg();
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, buf);
+  console.log(`wrote ${outPath} (${(buf.length / 1024).toFixed(1)} KB)`);
+}
+
+main();

--- a/src/components/PokerChart.astro
+++ b/src/components/PokerChart.astro
@@ -160,6 +160,15 @@ const payload = JSON.stringify(data);
 
 <script>
   import type { PokerChartData } from "./poker-chart-data";
+  import {
+    drawChart,
+    fmtMoney,
+    fmtSigned,
+    fmtFullDate,
+    GREEN,
+    RED,
+    type RenderState,
+  } from "./poker-chart-render";
 
   const root = document.getElementById("pk-root") as HTMLDivElement;
   const canvas = document.getElementById("pk-canvas") as HTMLCanvasElement;
@@ -169,89 +178,9 @@ const payload = JSON.stringify(data);
 
   const chartData: PokerChartData = JSON.parse(root.dataset.payload || "{}");
 
-  interface RenderState {
-    pad: { top: number; right: number; bottom: number; left: number };
-    minTime: number;
-    maxTime: number;
-    yMin: number;
-    yMax: number;
-    points: { t: number; cumulative: number; result: number }[];
-    chartW: number;
-    chartH: number;
-    includeYear: boolean;
-  }
   let renderState: RenderState | null = null;
 
-  const GREEN = "#34d399";
-  const RED = "#f87171";
   const MONO = "ui-monospace, SFMono-Regular, Menlo, Monaco, monospace";
-  const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-
-  function fmtMoney(n: number): string {
-    const sign = n < 0 ? "-$" : "$";
-    const abs = Math.abs(n);
-    if (abs >= 1e6) return sign + (abs / 1e6).toFixed(1) + "M";
-    if (abs >= 1e3) return sign + (abs / 1e3).toFixed(1) + "k";
-    // ponytail: keep cents on fractional small-stakes amounts; axis ticks are whole so they stay clean
-    if (!Number.isInteger(abs) && abs > 0) return sign + abs.toFixed(2);
-    return sign + Math.round(abs);
-  }
-
-  function fmtSigned(n: number): string {
-    return (n > 0 ? "+" : n < 0 ? "-" : "") + fmtMoney(Math.abs(n));
-  }
-
-  function niceNum(range: number, round: boolean): number {
-    if (range <= 0) return 1;
-    const exp = Math.floor(Math.log10(range));
-    const frac = range / Math.pow(10, exp);
-    let nice: number;
-    if (round) {
-      if (frac < 1.5) nice = 1;
-      else if (frac < 3) nice = 2;
-      else if (frac < 7) nice = 5;
-      else nice = 10;
-    } else {
-      if (frac <= 1) nice = 1;
-      else if (frac <= 2) nice = 2;
-      else if (frac <= 5) nice = 5;
-      else nice = 10;
-    }
-    return nice * Math.pow(10, exp);
-  }
-
-  function signedScale(minVal: number, maxVal: number, maxTicks = 6): number[] {
-    if (minVal === 0 && maxVal === 0) return [-1, 0, 1];
-    if (minVal > 0) minVal = 0;
-    if (maxVal < 0) maxVal = 0;
-    const span = niceNum(maxVal - minVal, false) || 1;
-    const step = niceNum(span / (maxTicks - 1), true);
-    const niceMin = Math.floor(minVal / step) * step;
-    const niceMax = Math.ceil(maxVal / step) * step;
-    const ticks: number[] = [];
-    for (let v = niceMin; v <= niceMax + step * 0.5; v += step)
-      ticks.push(Math.round(v * 1e6) / 1e6);
-    return ticks;
-  }
-
-  function dateTicks(minT: number, maxT: number, count = 6): number[] {
-    const span = maxT - minT;
-    if (span <= 0) return [minT];
-    const ticks: number[] = [];
-    for (let i = 0; i <= count; i++) ticks.push(minT + (span * i) / count);
-    return ticks;
-  }
-
-  function fmtDate(ts: number, includeYear: boolean): string {
-    const d = new Date(ts);
-    const base = MONTHS[d.getMonth()] + " " + d.getDate();
-    return includeYear ? base + " '" + String(d.getFullYear()).slice(-2) : base;
-  }
-
-  function fmtFullDate(ts: number): string {
-    const d = new Date(ts);
-    return MONTHS[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear();
-  }
 
   function render() {
     const dpr = window.devicePixelRatio || 1;
@@ -267,133 +196,14 @@ const payload = JSON.stringify(data);
     const ctx = canvas.getContext("2d")!;
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.scale(dpr, dpr);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    const points = chartData.points;
-    const pad = { top: 24, right: 16, bottom: 32, left: 64 };
-    const chartW = rect.width - pad.left - pad.right;
-    const chartH = height - pad.top - pad.bottom;
-
-    if (points.length === 0) {
-      renderState = null;
-      return;
-    }
-
-    let minTime = Infinity;
-    let maxTime = -Infinity;
-    let yMin = 0;
-    let yMax = 0;
-    for (const p of points) {
-      if (p.t < minTime) minTime = p.t;
-      if (p.t > maxTime) maxTime = p.t;
-      if (p.cumulative < yMin) yMin = p.cumulative;
-      if (p.cumulative > yMax) yMax = p.cumulative;
-    }
-    const yTicks = signedScale(yMin, yMax, 6);
-    const yLo = yTicks[0];
-    const yHi = yTicks[yTicks.length - 1];
-    const yRange = yHi - yLo || 1;
-    const timeRange = maxTime - minTime || 86400000;
-    const xTicks = dateTicks(minTime, maxTime, 6);
-    const includeYear = timeRange > 800 * 86400000;
-
-    const toX = (t: number) => pad.left + ((t - minTime) / timeRange) * chartW;
-    const toY = (v: number) => pad.top + chartH - ((v - yLo) / yRange) * chartH;
-    const zeroY = toY(0);
-
-    renderState = {
-      pad, minTime, maxTime, yMin: yLo, yMax: yHi, points, chartW, chartH, includeYear,
-    };
-
-    // horizontal grid + y labels
-    ctx.font = "10px " + MONO;
-    ctx.strokeStyle = "#1a1a1a";
-    ctx.lineWidth = 1;
-    ctx.textAlign = "right";
-    ctx.textBaseline = "middle";
-    for (const tick of yTicks) {
-      const y = Math.round(toY(tick)) + 0.5;
-      ctx.beginPath();
-      ctx.moveTo(pad.left, y);
-      ctx.lineTo(pad.left + chartW, y);
-      ctx.stroke();
-      ctx.fillStyle = "#525252";
-      ctx.fillText(fmtMoney(tick), pad.left - 8, toY(tick));
-    }
-
-    // vertical grid + x labels
-    ctx.textAlign = "center";
-    ctx.textBaseline = "top";
-    for (const tick of xTicks) {
-      const x = toX(tick);
-      if (x >= pad.left - 5 && x <= pad.left + chartW + 5) {
-        ctx.strokeStyle = "#1a1a1a";
-        ctx.beginPath();
-        ctx.moveTo(Math.round(x) + 0.5, pad.top);
-        ctx.lineTo(Math.round(x) + 0.5, pad.top + chartH);
-        ctx.stroke();
-        ctx.fillStyle = "#525252";
-        ctx.fillText(fmtDate(tick, includeYear), x, pad.top + chartH + 8);
-      }
-    }
-
-    // zero baseline
-    ctx.strokeStyle = "#333";
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(pad.left, Math.round(zeroY) + 0.5);
-    ctx.lineTo(pad.left + chartW, Math.round(zeroY) + 0.5);
-    ctx.stroke();
-
-    // area fill per step (green above zero, red below)
-    for (let i = 0; i < points.length - 1; i++) {
-      const x0 = toX(points[i].t);
-      const x1 = toX(points[i + 1].t);
-      const y = toY(points[i].cumulative);
-      const color = points[i].cumulative >= 0 ? GREEN : RED;
-      const grad = ctx.createLinearGradient(0, Math.min(y, zeroY), 0, Math.max(y, zeroY));
-      grad.addColorStop(0, color + "30");
-      grad.addColorStop(1, color + "05");
-      ctx.fillStyle = grad;
-      ctx.fillRect(x0, Math.min(y, zeroY), x1 - x0, Math.abs(zeroY - y));
-    }
-
-    // step-after line
-    ctx.strokeStyle = GREEN;
-    ctx.lineWidth = 1.75;
-    ctx.lineJoin = "round";
-    ctx.lineCap = "round";
-    ctx.beginPath();
-    for (let i = 0; i < points.length; i++) {
-      const x = toX(points[i].t);
-      const y = toY(points[i].cumulative);
-      if (i === 0) ctx.moveTo(x, y);
-      else {
-        ctx.lineTo(x, toY(points[i - 1].cumulative));
-        ctx.lineTo(x, y);
-      }
-    }
-    ctx.stroke();
-
-    // session dots
-    for (let i = 0; i < points.length; i++) {
-      const x = toX(points[i].t);
-      const y = toY(points[i].cumulative);
-      ctx.fillStyle = points[i].result >= 0 ? GREEN : RED;
-      ctx.beginPath();
-      ctx.arc(x, y, 2.5, 0, Math.PI * 2);
-      ctx.fill();
-    }
+    ctx.clearRect(0, 0, rect.width, height);
+    renderState = drawChart(ctx, chartData, rect.width, height, { fontFamily: MONO });
   }
 
   function drawHover(mouseX: number) {
     if (!renderState) return;
     const rs = renderState;
-    const dpr = window.devicePixelRatio || 1;
     const ctx = canvas.getContext("2d")!;
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.scale(dpr, dpr);
     render();
 
     const { pad, minTime, maxTime, points, chartW, chartH } = rs;

--- a/src/components/poker-chart-render.ts
+++ b/src/components/poker-chart-render.ts
@@ -1,0 +1,261 @@
+// Shared, environment-agnostic chart drawing. Used by:
+//   - PokerChart.astro <script> (browser canvas)
+//   - scripts/gen-og.ts (Node canvas via @napi-rs/canvas)
+// No DOM or Node imports here — callers pass a Canvas 2D-like context.
+
+import type { PokerChartData } from "./poker-chart-data";
+
+export const GREEN = "#34d399";
+export const RED = "#f87171";
+export const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+export interface ChartGradient {
+  addColorStop(offset: number, color: string): void;
+}
+
+// Structural slice of CanvasRenderingContext2D that both the DOM context and
+// @napi-rs/canvas's SKRSContext2D satisfy. Keeps this module dependency-free.
+// Style props accept a color string, a gradient, or an opaque pattern object
+// (CanvasGradient/CanvasPattern differ between DOM and @napi-rs/canvas; `object`
+// covers both without coupling this module to either).
+export interface ChartCtx {
+  fillStyle: string | ChartGradient | object;
+  strokeStyle: string | ChartGradient | object;
+  font: string;
+  textAlign: string;
+  textBaseline: string;
+  lineWidth: number;
+  lineJoin: string;
+  lineCap: string;
+  beginPath(): void;
+  closePath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  stroke(): void;
+  fill(): void;
+  fillText(text: string, x: number, y: number): void;
+  fillRect(x: number, y: number, w: number, h: number): void;
+  arc(x: number, y: number, r: number, start: number, end: number): void;
+  createLinearGradient(x0: number, y0: number, x1: number, y2: number): ChartGradient;
+}
+
+export interface RenderState {
+  pad: { top: number; right: number; bottom: number; left: number };
+  minTime: number;
+  maxTime: number;
+  yMin: number;
+  yMax: number;
+  points: { t: number; cumulative: number; result: number }[];
+  chartW: number;
+  chartH: number;
+  includeYear: boolean;
+}
+
+export interface DrawChartOpts {
+  fontFamily: string;
+  scale?: number; // multiplies font sizes + padding; 1 = on-page defaults
+}
+
+const DEFAULT_PAD = { top: 24, right: 16, bottom: 32, left: 64 };
+
+export function fmtMoney(n: number): string {
+  const sign = n < 0 ? "-$" : "$";
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return sign + (abs / 1e6).toFixed(1) + "M";
+  if (abs >= 1e3) return sign + (abs / 1e3).toFixed(1) + "k";
+  // keep cents on fractional small-stakes amounts; axis ticks are whole so they stay clean
+  if (!Number.isInteger(abs) && abs > 0) return sign + abs.toFixed(2);
+  return sign + Math.round(abs);
+}
+
+export function fmtSigned(n: number): string {
+  return (n > 0 ? "+" : n < 0 ? "-" : "") + fmtMoney(Math.abs(n));
+}
+
+export function niceNum(range: number, round: boolean): number {
+  if (range <= 0) return 1;
+  const exp = Math.floor(Math.log10(range));
+  const frac = range / Math.pow(10, exp);
+  let nice: number;
+  if (round) {
+    if (frac < 1.5) nice = 1;
+    else if (frac < 3) nice = 2;
+    else if (frac < 7) nice = 5;
+    else nice = 10;
+  } else {
+    if (frac <= 1) nice = 1;
+    else if (frac <= 2) nice = 2;
+    else if (frac <= 5) nice = 5;
+    else nice = 10;
+  }
+  return nice * Math.pow(10, exp);
+}
+
+export function signedScale(minVal: number, maxVal: number, maxTicks = 6): number[] {
+  if (minVal === 0 && maxVal === 0) return [-1, 0, 1];
+  if (minVal > 0) minVal = 0;
+  if (maxVal < 0) maxVal = 0;
+  const span = niceNum(maxVal - minVal, false) || 1;
+  const step = niceNum(span / (maxTicks - 1), true);
+  const niceMin = Math.floor(minVal / step) * step;
+  const niceMax = Math.ceil(maxVal / step) * step;
+  const ticks: number[] = [];
+  for (let v = niceMin; v <= niceMax + step * 0.5; v += step)
+    ticks.push(Math.round(v * 1e6) / 1e6);
+  return ticks;
+}
+
+export function dateTicks(minT: number, maxT: number, count = 6): number[] {
+  const span = maxT - minT;
+  if (span <= 0) return [minT];
+  const ticks: number[] = [];
+  for (let i = 0; i <= count; i++) ticks.push(minT + (span * i) / count);
+  return ticks;
+}
+
+export function fmtDate(ts: number, includeYear: boolean): string {
+  const d = new Date(ts);
+  const base = MONTHS[d.getMonth()] + " " + d.getDate();
+  return includeYear ? base + " '" + String(d.getFullYear()).slice(-2) : base;
+}
+
+export function fmtFullDate(ts: number): string {
+  const d = new Date(ts);
+  return MONTHS[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear();
+}
+
+// Draws the chart into the current coordinate space. Caller is responsible for
+// sizing the canvas and (in the browser) applying devicePixelRatio scaling +
+// clearing. Returns render state for hover hit-testing, or null if no points.
+export function drawChart(
+  ctx: ChartCtx,
+  data: PokerChartData,
+  width: number,
+  height: number,
+  opts: DrawChartOpts,
+): RenderState | null {
+  const scale = opts.scale ?? 1;
+  const pad = {
+    top: DEFAULT_PAD.top * scale,
+    right: DEFAULT_PAD.right * scale,
+    bottom: DEFAULT_PAD.bottom * scale,
+    left: DEFAULT_PAD.left * scale,
+  };
+  const points = data.points;
+  const chartW = width - pad.left - pad.right;
+  const chartH = height - pad.top - pad.bottom;
+
+  if (points.length === 0) return null;
+
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  let yMin = 0;
+  let yMax = 0;
+  for (const p of points) {
+    if (p.t < minTime) minTime = p.t;
+    if (p.t > maxTime) maxTime = p.t;
+    if (p.cumulative < yMin) yMin = p.cumulative;
+    if (p.cumulative > yMax) yMax = p.cumulative;
+  }
+  const yTicks = signedScale(yMin, yMax, 6);
+  const yLo = yTicks[0];
+  const yHi = yTicks[yTicks.length - 1];
+  const yRange = yHi - yLo || 1;
+  const timeRange = maxTime - minTime || 86400000;
+  const xTicks = dateTicks(minTime, maxTime, 6);
+  const includeYear = timeRange > 800 * 86400000;
+
+  const toX = (t: number) => pad.left + ((t - minTime) / timeRange) * chartW;
+  const toY = (v: number) => pad.top + chartH - ((v - yLo) / yRange) * chartH;
+  const zeroY = toY(0);
+
+  const labelFont = `${10 * scale}px ${opts.fontFamily}`;
+
+  // horizontal grid + y labels
+  ctx.font = labelFont;
+  ctx.strokeStyle = "#1a1a1a";
+  ctx.lineWidth = 1;
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (const tick of yTicks) {
+    const y = Math.round(toY(tick)) + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(pad.left, y);
+    ctx.lineTo(pad.left + chartW, y);
+    ctx.stroke();
+    ctx.fillStyle = "#525252";
+    ctx.fillText(fmtMoney(tick), pad.left - 8 * scale, toY(tick));
+  }
+
+  // vertical grid + x labels
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  for (const tick of xTicks) {
+    const x = toX(tick);
+    if (x >= pad.left - 5 && x <= pad.left + chartW + 5) {
+      ctx.strokeStyle = "#1a1a1a";
+      ctx.beginPath();
+      ctx.moveTo(Math.round(x) + 0.5, pad.top);
+      ctx.lineTo(Math.round(x) + 0.5, pad.top + chartH);
+      ctx.stroke();
+      ctx.fillStyle = "#525252";
+      ctx.fillText(fmtDate(tick, includeYear), x, pad.top + chartH + 8 * scale);
+    }
+  }
+
+  // zero baseline
+  ctx.strokeStyle = "#333";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(pad.left, Math.round(zeroY) + 0.5);
+  ctx.lineTo(pad.left + chartW, Math.round(zeroY) + 0.5);
+  ctx.stroke();
+
+  // area fill per step (green above zero, red below)
+  for (let i = 0; i < points.length - 1; i++) {
+    const x0 = toX(points[i].t);
+    const x1 = toX(points[i + 1].t);
+    const y = toY(points[i].cumulative);
+    const color = points[i].cumulative >= 0 ? GREEN : RED;
+    const grad = ctx.createLinearGradient(0, Math.min(y, zeroY), 0, Math.max(y, zeroY));
+    grad.addColorStop(0, color + "30");
+    grad.addColorStop(1, color + "05");
+    ctx.fillStyle = grad;
+    ctx.fillRect(x0, Math.min(y, zeroY), x1 - x0, Math.abs(zeroY - y));
+  }
+
+  // step-after line
+  ctx.strokeStyle = GREEN;
+  ctx.lineWidth = 1.75 * scale;
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  for (let i = 0; i < points.length; i++) {
+    const x = toX(points[i].t);
+    const y = toY(points[i].cumulative);
+    if (i === 0) ctx.moveTo(x, y);
+    else {
+      ctx.lineTo(x, toY(points[i - 1].cumulative));
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.stroke();
+
+  // session dots
+  for (let i = 0; i < points.length; i++) {
+    const x = toX(points[i].t);
+    const y = toY(points[i].cumulative);
+    ctx.fillStyle = points[i].result >= 0 ? GREEN : RED;
+    ctx.beginPath();
+    ctx.arc(x, y, 2.5 * scale, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  return {
+    pad, minTime, maxTime, yMin: yLo, yMax: yHi, points, chartW, chartH, includeYear,
+  };
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,9 +4,15 @@ import "../styles/global.css";
 interface Props {
     title: string;
     description?: string;
+    ogImage?: string; // path under /public, e.g. "/og/poker.png"
 }
 
-const { title, description = "collinpfeifer.dev" } = Astro.props;
+const { title, description = "collinpfeifer.dev", ogImage } = Astro.props;
+
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+const ogImageUrl = ogImage
+    ? new URL(ogImage, Astro.site).href
+    : undefined;
 ---
 
 <!doctype html>
@@ -17,7 +23,25 @@ const { title, description = "collinpfeifer.dev" } = Astro.props;
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" href="/favicon.png" />
         <meta name="generator" content={Astro.generator} />
+        <link rel="canonical" href={canonical} />
         <title>{title}</title>
+
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        {ogImageUrl && <meta property="og:image" content={ogImageUrl} />}
+        {ogImageUrl && (
+            <meta property="og:image:width" content="1200" />
+        )}
+        {ogImageUrl && (
+            <meta property="og:image:height" content="630" />
+        )}
+
+        <meta name="twitter:card" content={ogImageUrl ? "summary_large_image" : "summary"} />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        {ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />

--- a/src/pages/poker.astro
+++ b/src/pages/poker.astro
@@ -7,6 +7,7 @@ import Header from "../components/Header.astro";
 <Layout
   title="collinpfeifer.dev"
   description="Live poker graph"
+  ogImage="/og/poker.png"
 >
   <div class="min-h-screen text-white bg-black">
     <Header active="poker">


### PR DESCRIPTION
## What

Makes the poker graph embeddable as a rich link card in Apple Notes (and any link-preview surface — iMessage, Slack, Twitter, etc.).

## Why

Apple Notes doesn't run JS, render `<canvas>`, or embed iframes, so the interactive chart can't live *inside* a note. The closest real equivalent is a rich link card: paste the URL, Notes reads OpenGraph tags, shows a snapshot image, tap to open the live page. This adds that snapshot + the meta tags to make it work.

## Changes

- **`src/components/poker-chart-render.ts`** (new) — shared `drawChart()` + helpers + `ChartCtx` type. One drawing code path used by both the live page and the OG image, so the preview always matches the site.
- **`src/components/PokerChart.astro`** — `<script>` refactored to call `drawChart()`; hover/stats stay inline. Behavior unchanged, ~150 lines of duplicated drawing code removed.
- **`scripts/gen-og.ts`** (new) — build-time 1200×630 PNG via `@napi-rs/canvas`. Parses `log.md` (same data layer as the page), registers the NeueMachina OTFs already in `public/fonts/`, composes header + net + stats + chart.
- **`src/layouts/Layout.astro`** — `og:`/`twitter:`/canonical meta with absolute URLs via `Astro.site`. `ogImage` is opt-in per page.
- **`astro.config.mjs`** — `site: https://collinpfeifer.dev`.
- **`package.json`** — `build` now runs `gen:og` before `astro build`; generated PNG gitignored (regenerated each build, no binary churn).

## Verification

- `astro check`: 0 errors / 0 warnings / 0 hints
- `bun run build`: succeeds; `gen:og` runs first, image copied to `dist/og/poker.png`
- Built `dist/poker/index.html` contains `og:image`, `og:image:width/height`, `twitter:card=summary_large_image`, canonical
- Vision check (zai) on the PNG: header, red `-$18.00` net, 4 stats, step-after chart with green/red areas + dots + axis labels — renders correctly

## Usage

Once merged + deployed: paste `https://collinpfeifer.dev/poker/` into an Apple Note → graph card appears → tap to open the live interactive chart. Adding a session to `log.md` + redeploying refreshes the card image (existing Notes previews may cache — a Notes limitation).